### PR TITLE
Add MCP integration for Kanazawa open data

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,18 @@ cp .env.example .env
 # .envファイルを編集して必要な環境変数を設定
 ```
 
-3. Docker Composeで起動
+3. オープンデータの取得とインポート
+```bash
+docker compose run --rm backend python scripts/fetch_opendata.py
+docker compose run --rm backend python scripts/import_data.py
+```
+
+4. Docker Composeで起動
 ```bash
 docker-compose up --build
 ```
 
-4. ブラウザでアクセス
+5. ブラウザでアクセス
 ```
 http://localhost:3000
 ```

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,9 +1,10 @@
 from fastapi import FastAPI, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
-from typing import List, Optional, Dict, Any
+from typing import Dict, Any
 import uvicorn
 from mcp.service import MCPService
+import openai
 
 app = FastAPI(title="金沢市 MCP API")
 
@@ -56,10 +57,44 @@ async def execute_tool(request: MCPToolRequest):
 @app.post("/api/chat", response_model=ChatResponse)
 async def chat(request: ChatRequest):
     try:
-        # TODO: OpenAI APIを使用してMCPツールを呼び出す処理を実装
-        return ChatResponse(
-            answer="ご質問ありがとうございます！\n現在、APIの実装中です。\nもうしばらくお待ちください。"
+        query = request.query
+        if "観光" in query:
+            result = await mcp_service.execute_tool(
+                "search_tourist_spots", {"keyword": query, "limit": 5}
+            )
+            spots_text = "\n".join(
+                f"{s['name']} - {s['description']}" for s in result.get("spots", [])
+            )
+            system_prompt = (
+                "あなたは金沢市の観光案内アシスタントです。以下の観光スポット情報を参考に回答してください。\n"
+                + spots_text
+            )
+        elif "交通" in query or "バス" in query or "駅" in query:
+            stop_type = "bus_stop" if "バス" in query else "train_station"
+            result = await mcp_service.execute_tool(
+                "get_transportation_info", {"type": stop_type}
+            )
+            stops_text = "\n".join(
+                f"{s['name']}({s['type']})" for s in result.get("stops", [])
+            )
+            system_prompt = (
+                "あなたは金沢市の交通案内アシスタントです。以下の交通情報を参考に回答してください。\n"
+                + stops_text
+            )
+        else:
+            system_prompt = "あなたは金沢市の案内アシスタントです。"
+
+        response = openai.ChatCompletion.create(
+            model="gpt-3.5-turbo",
+            messages=[
+                {"role": "system", "content": system_prompt},
+                {"role": "user", "content": query},
+            ],
+            temperature=0.2,
+            max_tokens=500,
         )
+        answer = response.choices[0].message.content
+        return ChatResponse(answer=answer)
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 


### PR DESCRIPTION
## Summary
- fetch open data on startup via README instructions
- implement DB queries in MCP service
- update chat API to use MCP data and OpenAI to answer
- call chat API from frontend input

## Testing
- `pytest -q` *(fails: command not found)*
- `npm run lint` *(fails: next not found)*