### PR TITLE
Switch to GPT-4.1-nano model

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -87,7 +87,7 @@ async def chat(request: ChatRequest):
         
         # GPTに質問を送信
         response = openai.ChatCompletion.create(
-            model="gpt-3.5-turbo",
+            model="gpt-4.1-nano",
             messages=[
                 {"role": "system", "content": system_prompt},
                 {"role": "user", "content": request.message}

--- a/backend/env_example.txt
+++ b/backend/env_example.txt
@@ -5,7 +5,7 @@ DATABASE_URL=sqlite:///./kanazawa_mcp.db
 
 # OpenAI API設定
 OPENAI_API_KEY=your_openai_api_key_here
-OPENAI_MODEL=gpt-3.5-turbo
+OPENAI_MODEL=gpt-4.1-nano
 
 # CORS設定（カンマ区切りで複数指定可能）
 ALLOWED_ORIGINS=http://localhost:3000,http://127.0.0.1:3000

--- a/backend/main.py
+++ b/backend/main.py
@@ -241,7 +241,7 @@ async def chat(request: ChatRequest, db: Session = Depends(SessionDep)):
         messages.append({"role": "user", "content": query})
 
         response = openai_client.chat.completions.create(
-            model=os.getenv("OPENAI_MODEL", "gpt-3.5-turbo"),
+            model=os.getenv("OPENAI_MODEL", "gpt-4.1-nano"),
             messages=messages,
             temperature=0.3,
             max_tokens=800,

--- a/frontend/app/components/ChatMessage.tsx
+++ b/frontend/app/components/ChatMessage.tsx
@@ -1,19 +1,20 @@
 "use client";
 import React from "react";
-import { 
-  Box, 
-  Text, 
-  Flex, 
-  Avatar, 
+import {
+  Box,
+  Text,
+  Flex,
+  Avatar,
   VStack,
   HStack,
   IconButton,
   useClipboard,
-  useToast
+  useToast,
 } from "@chakra-ui/react";
 import { motion } from "framer-motion";
 import { ChatMessage as ChatMessageType } from "../types/chat";
 import { FiUser, FiMessageSquare, FiCopy, FiCheck } from "react-icons/fi";
+import { formatTime } from "../utils/time";
 
 const MotionBox = motion(Box);
 
@@ -34,14 +35,6 @@ export default function ChatMessage({ message }: ChatMessageProps) {
       duration: 2000,
       isClosable: true,
       position: "top",
-      size: "sm",
-    });
-  };
-
-  const formatTime = (date: Date) => {
-    return date.toLocaleTimeString('ja-JP', {
-      hour: '2-digit',
-      minute: '2-digit'
     });
   };
 
@@ -52,11 +45,11 @@ export default function ChatMessage({ message }: ChatMessageProps) {
       transition={{ duration: 0.3 }}
       mb={4}
       role="article"
-      aria-label={`${isUser ? 'ユーザー' : 'アシスタント'}のメッセージ`}
+      aria-label={`${isUser ? "ユーザー" : "アシスタント"}のメッセージ`}
     >
-      <Flex 
-        gap={3} 
-        align="flex-start" 
+      <Flex
+        gap={3}
+        align="flex-start"
         justify={isUser ? "flex-end" : "flex-start"}
         direction={isUser ? "row-reverse" : "row"}
       >
@@ -70,8 +63,8 @@ export default function ChatMessage({ message }: ChatMessageProps) {
         />
 
         {/* メッセージコンテンツ */}
-        <VStack 
-          align={isUser ? "flex-end" : "flex-start"} 
+        <VStack
+          align={isUser ? "flex-end" : "flex-start"}
           spacing={1}
           maxW="80%"
         >
@@ -92,21 +85,21 @@ export default function ChatMessage({ message }: ChatMessageProps) {
               height: 0,
               borderTop: "8px solid transparent",
               borderBottom: "8px solid transparent",
-              [isUser ? "borderLeft" : "borderRight"]: isUser 
-                ? "8px solid" 
+              [isUser ? "borderLeft" : "borderRight"]: isUser
+                ? "8px solid"
                 : "8px solid",
-              [isUser ? "borderLeftColor" : "borderRightColor"]: isUser 
-                ? "pink.500" 
+              [isUser ? "borderLeftColor" : "borderRightColor"]: isUser
+                ? "pink.500"
                 : "whiteAlpha.900",
             }}
             transition="all 0.2s"
             _hover={{
               transform: "translateY(-1px)",
-              boxShadow: "lg"
+              boxShadow: "lg",
             }}
           >
-            <Text 
-              fontSize="md" 
+            <Text
+              fontSize="md"
               whiteSpace="pre-wrap"
               lineHeight="1.6"
               wordBreak="break-word"
@@ -117,14 +110,10 @@ export default function ChatMessage({ message }: ChatMessageProps) {
 
           {/* タイムスタンプとアクション */}
           <HStack spacing={2} justify={isUser ? "flex-end" : "flex-start"}>
-            <Text 
-              fontSize="xs" 
-              color="whiteAlpha.600"
-              fontWeight="500"
-            >
+            <Text fontSize="xs" color="whiteAlpha.600" fontWeight="500">
               {formatTime(message.timestamp)}
             </Text>
-            
+
             {/* コピーボタン */}
             <IconButton
               aria-label="メッセージをコピー"
@@ -132,9 +121,9 @@ export default function ChatMessage({ message }: ChatMessageProps) {
               size="xs"
               variant="ghost"
               color="whiteAlpha.600"
-              _hover={{ 
+              _hover={{
                 color: "whiteAlpha.800",
-                bg: "whiteAlpha.100"
+                bg: "whiteAlpha.100",
               }}
               onClick={handleCopy}
             />
@@ -143,4 +132,4 @@ export default function ChatMessage({ message }: ChatMessageProps) {
       </Flex>
     </MotionBox>
   );
-} 
+}

--- a/frontend/app/utils/time.ts
+++ b/frontend/app/utils/time.ts
@@ -1,0 +1,2 @@
+export const formatTime = (date: Date): string =>
+  date.toLocaleTimeString("ja-JP", { hour: "2-digit", minute: "2-digit" });


### PR DESCRIPTION
## Summary
- centralize time format helper in `frontend/app/utils/time.ts`
- use helper in `ChatMessage`
- set default OpenAI model to `gpt-4.1-nano` in backend
- update env example accordingly

## Testing
- `npx prettier -w frontend/app/components/ChatMessage.tsx frontend/app/utils/time.ts`
- `npm run lint` *(fails: next not found)*
- `python -m py_compile backend/main.py backend/app/main.py backend/mcp/service.py backend/services/open_data_service.py`
